### PR TITLE
Update clean-css dependency to 3.0.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function minifyCSSTransform(opt, file) {
     // Use the buffered content
     minify(opt, file, buf, function (errors, data) {
       // Bring it back to streams
-      cb(null, new Buffer(data));
+      cb(null, new Buffer(data.styles));
     });
   };
 }
@@ -82,7 +82,7 @@ function minifyCSSGulp(opt){
 
         // Restore original "relativeTo" value
         opt.relativeTo = relativeToTmp;
-        file.contents = new Buffer(newContents);
+        file.contents = new Buffer(newContents.styles);
 
         done(errors ? errors[0] : null, file);
       });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "gulp-util": "~3.0.1",
-    "clean-css": "~2.2.13",
+    "clean-css": "~3.0.4",
     "through2": "^0.6.1",
     "bufferstreams": "0.0.2",
     "memory-cache": "0.0.5"

--- a/test/minify.js
+++ b/test/minify.js
@@ -22,7 +22,7 @@ describe('gulp-minify-css minification', function() {
       .pipe(minifyCSS(opts))
       .pipe(es.map(function(file){
         var source = fs.readFileSync(filename),
-          expected = new CleanCSS(opts).minify(source.toString());
+          expected = new CleanCSS(opts).minify(source.toString()).styles;
         expect(expected).to.be.equal(file.contents.toString());
         done();
       }));
@@ -44,7 +44,7 @@ describe('gulp-minify-css minification', function() {
       .pipe(minifyCSS(opts))
       .pipe(es.map(function(file){
         var source = fs.readFileSync(filename),
-          expected = new CleanCSS(opts).minify(source.toString());
+          expected = new CleanCSS(opts).minify(source.toString()).styles;
         file.contents.pipe(es.wait(function(err, data) {
           expect(expected).to.be.equal(data.toString());
           done();
@@ -71,7 +71,7 @@ describe('gulp-minify-css minification', function() {
         .pipe(es.map(function(file){
           var source = fs.readFileSync(filename);
           new CleanCSS(opts).minify(source.toString(), function (errors, expected) {
-            expect(expected).to.be.equal(file.contents.toString());
+            expect(expected.styles).to.be.equal(file.contents.toString());
             done();
           });
         }));


### PR DESCRIPTION
I updated the [`clean-css`](https://www.npmjs.com/package/clean-css) dependency to the latest version 3.0.4. This adds some [much needed options](https://www.npmjs.com/package/clean-css#how-to-use-clean-css-programmatically-).

I have updated all of the tests and all(11) pass.

Please publish this in a new npm release.

For now you can install via: `npm install MadLittleMods/gulp-minify-css`