### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/jonathanepollack/gulp-minify-css.png?branch=master)](https://travis-ci.org/jonathanepollack/gulp-minify-css)
+[![Build Status](https://travis-ci.org/jonathanepollack/gulp-minify-css.svg?branch=master)](https://travis-ci.org/jonathanepollack/gulp-minify-css)
 
 ## Breaking Changes from v0.3 to v0.4 (due to clean-css)
 
@@ -30,7 +30,7 @@ This is just a simple gulp plugin, which means it's nothing more than a thin wra
 
 ## Installion
 
-```
+```sh
 npm install --save-dev gulp-minify-css
 ```
 
@@ -41,7 +41,7 @@ var gulp = require('gulp'),
 		minifyCSS = require('gulp-minify-css');
 
 gulp.task('minify-css', function() {
-  gulp.src('./static/css/*.css')
+  return gulp.src('./static/css/*.css')
     .pipe(minifyCSS({keepBreaks:true}))
     .pipe(gulp.dest('./dist/'))
 });
@@ -80,7 +80,7 @@ var minifyCSS = require('gulp-minify-css');
 var sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('minify-css', function() {
-  gulp.src('./src/*.css')
+  return gulp.src('./src/*.css')
     .pipe(sourcemaps.init())
     .pipe(minifyCSS())
     .pipe(sourcemaps.write())


### PR DESCRIPTION
* Use SVG badge instead of PNG badge
  * SVG badges look beautiful on retina displays.
* `Return` gulp.src streams in all examples. (close #67)
