### PR TITLE
Fix sourcemap paths when file.base is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function gulpMinifyCSS(options) {
               return src;
             }
 
-            return path.relative(file.base, src === '$stdin' ? file.path : src);
+            return src === '$stdin' ? file.relative : src;
           });
 
           applySourceMap(file, map);


### PR DESCRIPTION
In my configuration, file.base is "src", file.path is "C:/Work/myproject/src/css/app.css", file.relative is "css/app.css", and map.sources is ["$stdin", "css/node_modules/purecss/build/pure.css", "css/app.css"]. It looks like calling path.relative(base, src), where src is an item of map.sources, is wrong, since src [is already relative to base](https://github.com/floridoo/gulp-sourcemaps#plugin-developers-only-how-to-add-source-map-support-to-plugins). This was giving me the following errors:

    gulp-sourcemap-write: No source content for "../css/node_modules/purecss/build/pure.css". Loading from file.
    gulp-sourcemap-write: source file not found: c:\Work\myproject\css\node_modules\purecss\build\pure.css
    gulp-sourcemap-write: No source content for "../css/app.css". Loading from file.
    gulp-sourcemap-write: source file not found: c:\Work\myproject\css\app.css